### PR TITLE
RTL881[24] wifi card RC uplink caused video packet loss FIX.

### DIFF
--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -93,7 +93,7 @@ function tx_function {
 		if [ "$DRIVER" != "ath9k_htc" ]; then # in single mode and ralink cards always, use frametype 1 (data)
 			VIDEO_FRAMETYPE=0
 		        if [ "$DRIVER" == "rtl88xxau" ]; then
-		        	VIDEO_FRAMETYPE=1
+		        	VIDEO_FRAMETYPE=2
 			fi
 			RALINK=1
 		fi
@@ -135,8 +135,9 @@ function tx_function {
 			echo "CTS Protection disabled in config"
 			CTS=N
 		else
-			if [ "$DRIVER" == "ath9k_htc" ]; then
+			if [ "$DRIVER" == "ath9k_htc" ] || [ "$DRIVER" == "rtl88xxau" ]; then
 				echo "CTS Protection enabled in config"
+				VIDEO_FRAMETYPE=1
 				CTS=Y
 			else
 				echo "CTS Protection not supported!"


### PR DESCRIPTION
RTL881[24] wifi card  enable RC and uplink, UseMCS=Y and CTS_PROTECTION=N are required.EncryptionOrRange=Range Or Encryption can be either.