### PR TITLE
Rssitx/rx enables 802.11n MCS based on card type

### DIFF
--- a/wifibroadcast-base/rssirx.c
+++ b/wifibroadcast-base/rssirx.c
@@ -31,6 +31,18 @@ typedef struct  {
 int flagHelp = 0;
 
 wifibroadcast_rx_status_t *rx_status = NULL;
+long long current_timestamp() {
+    struct timeval te; 
+    gettimeofday(&te, NULL); // get current time
+    long long milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; // caculate milliseconds
+    return milliseconds;
+}
+
+int dbm[6];
+int dbm_last[6];
+long long dbm_ts_prev[6];
+long long dbm_ts_now[6];
+wifibroadcast_rx_status_t *rx_status_uplink = NULL;
 wifibroadcast_rx_status_t_rc *rx_status_rc = NULL;
 wifibroadcast_rx_status_t_sysair *rx_status_sysair = NULL;
 
@@ -169,9 +181,25 @@ uint8_t process_packet(monitor_interface_t *interface, int adapter_no) {
 		case IEEE80211_RADIOTAP_FLAGS:
 			prd.m_nRadiotapFlags = *rti.this_arg;
 			break;
-//		case IEEE80211_RADIOTAP_DBM_ANTSIGNAL:
-//			rx_status->adapter[adapter_no].current_signal_dbm = (int8_t)(*rti.this_arg);
-//			break;
+		case IEEE80211_RADIOTAP_DBM_ANTSIGNAL:
+			//rx_status->adapter[adapter_no].current_signal_dbm = (int8_t)(*rti.this_arg);
+
+			dbm_last[adapter_no] = dbm[adapter_no];
+			dbm[adapter_no] = (int8_t)(*rti.this_arg);
+
+			if (dbm[adapter_no] > dbm_last[adapter_no]) { // if we have a better signal than last time, ignore
+			    dbm[adapter_no] = dbm_last[adapter_no];
+			}
+
+			dbm_ts_now[adapter_no] = current_timestamp();
+			if (dbm_ts_now[adapter_no] - dbm_ts_prev[adapter_no] > 220) {
+			    dbm_ts_prev[adapter_no] = current_timestamp();
+//			    fprintf(stderr, "miss: %d   last: %d\n", packets_missing,packets_missing_last);
+			    rx_status->adapter[adapter_no].current_signal_dbm = dbm[adapter_no];
+			    dbm[adapter_no] = 99;
+			    dbm_last[adapter_no] = 99;
+			}
+			break;
 		}
 	}
 	pu8Payload += u16HeaderLen + interface->n80211HeaderLength;
@@ -191,8 +219,8 @@ uint8_t process_packet(monitor_interface_t *interface, int adapter_no) {
 //	printf ("cts:%d\n",payloaddata.cts);
 //	printf ("undervolt:%d\n",payloaddata.undervolt);
 
-	rx_status->adapter[0].current_signal_dbm = payloaddata.signal;
-	rx_status->lost_packet_cnt = payloaddata.lostpackets;
+	rx_status_uplink->adapter[0].current_signal_dbm = payloaddata.signal;
+	rx_status_uplink->lost_packet_cnt = payloaddata.lostpackets;
 	rx_status_rc->adapter[0].current_signal_dbm = payloaddata.signal_rc;
 	rx_status_rc->lost_packet_cnt = payloaddata.lostpackets_rc;
 	rx_status_sysair->cpuload = payloaddata.cpuload;
@@ -220,15 +248,16 @@ void status_memory_init(wifibroadcast_rx_status_t *s) {
 	s->lost_packet_cnt = 0;
 	s->tx_restart_cnt = 0;
 	s->wifi_adapter_cnt = 0;
+	s->kbitrate = 0;
 
 	int i;
 	for(i=0; i<8; ++i) {
 		s->adapter[i].received_packet_cnt = 0;
 		s->adapter[i].wrong_crc_cnt = 0;
 		s->adapter[i].current_signal_dbm = -126;
+		s->adapter[i].type = 2; // set to 2 to see if it didnt get set later ...
 	}
 }
-
 void status_memory_init_rc(wifibroadcast_rx_status_t_rc *s) {
 	s->received_block_cnt = 0;
 	s->damaged_block_cnt = 0;
@@ -258,8 +287,20 @@ void status_memory_init_sysair(wifibroadcast_rx_status_t_sysair *s) {
 	s->undervolt = 0;
 }
 
-
 wifibroadcast_rx_status_t *status_memory_open(void) {
+	char buf[128];
+	int fd;
+	sprintf(buf, "/wifibroadcast_rx_status_%d", 0);
+	fd = shm_open(buf, O_RDWR, S_IRUSR | S_IWUSR);
+	if(fd < 0) { perror("shm_open"); exit(1); }
+	void *retval = mmap(NULL, sizeof(wifibroadcast_rx_status_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (retval == MAP_FAILED) { perror("mmap"); exit(1); }
+	wifibroadcast_rx_status_t *tretval = (wifibroadcast_rx_status_t*)retval;
+	status_memory_init(tretval);
+	return tretval;
+}
+
+wifibroadcast_rx_status_t *status_memory_open_uplink(void) {
 	char buf[128];
 	int fd;
 	sprintf(buf, "/wifibroadcast_rx_status_uplink");
@@ -335,6 +376,15 @@ int main(int argc, char *argv[]) {
 
 	rx_status = status_memory_open();
 	rx_status->wifi_adapter_cnt = num_interfaces;
+	
+	int g;
+    for(g=0; g<8; ++g) {
+	    rx_status->adapter[g].current_signal_dbm = -126;
+	    rx_status->adapter[g].signal_good = 1;
+    }
+
+	rx_status_uplink = status_memory_open_uplink();
+	rx_status_uplink->wifi_adapter_cnt = num_interfaces;
 
 	rx_status_rc = status_memory_open_rc();
 	rx_status_rc->wifi_adapter_cnt = num_interfaces;

--- a/wifibroadcast-base/rssirx.c
+++ b/wifibroadcast-base/rssirx.c
@@ -71,8 +71,8 @@ void open_and_configure_interface(const char *name, monitor_interface_t *interfa
 	int nLinkEncap = pcap_datalink(interface->ppcap);
 
 	if (nLinkEncap == DLT_IEEE802_11_RADIO) {
-		interface->n80211HeaderLength = 0x18; // 24 bytes
-		sprintf(szProgram, "ether[0x00:2] == 0x0802 && ether[0x04:1] == 0xff"); // match on frametype, 1st byte of mac (ff) and portnumber (255 = 127 for rssi)
+	   //sprintf(szProgram, "ether[0x00:2] == 0x0802 && ether[0x04:1] == 0x7F"); // match on frametype, 1st byte of mac (0x7F) for portnumber 63((127-1)/2 for rssi)
+		sprintf(szProgram, "(ether[0x00:2] == 0x0801 || ether[0x00:2] == 0x0802 || ether[0x00:4] == 0xb4010000) && ether[0x04:1] == 0x7F");	
 	} else {
 		fprintf(stderr, "ERROR: unknown encapsulation on %s! check if monitor mode is supported and enabled\n", name);
 		exit(1);
@@ -140,6 +140,22 @@ uint8_t process_packet(monitor_interface_t *interface, int adapter_no) {
 	// fetch radiotap header length from radiotap header (seems to be 36 for Atheros and 18 for Ralink)
 	u16HeaderLen = (pu8Payload[2] + (pu8Payload[3] << 8));
 //	fprintf(stderr, "u16headerlen: %d\n", u16HeaderLen);
+
+    pu8Payload += u16HeaderLen;
+    switch (pu8Payload[1]) {
+    case 0x01: // data short, rts (telemetry)
+//	fprintf(stderr, "data short or rts telemetry frame\n");
+        interface->n80211HeaderLength = 0x05;
+        break;
+    case 0x02: // data (telemetry)
+//	fprintf(stderr, "data telemetry frame\n");
+        interface->n80211HeaderLength = 0x18;
+        break;
+    default:
+        break;
+    }
+    pu8Payload -= u16HeaderLen;
+
 //	fprintf(stderr, "ppcapPacketHeader->len: %d\n", ppcapPacketHeader->len);
 	if (ppcapPacketHeader->len < (u16HeaderLen + interface->n80211HeaderLength)) exit(1);
 

--- a/wifibroadcast-base/rssitx.c
+++ b/wifibroadcast-base/rssitx.c
@@ -24,8 +24,50 @@ int flagHelp = 0;
 
 int sock=0;
 int socks[5];
+int type[5];
 
 bool no_signal, no_signal_rc;
+
+struct framedata_n {
+    uint8_t rt1;
+    uint8_t rt2;
+    uint8_t rt3;
+    uint8_t rt4;
+    uint8_t rt5;
+    uint8_t rt6;
+    uint8_t rt7;
+    uint8_t rt8;
+
+    uint8_t rt9;
+    uint8_t rt10;
+    uint8_t rt11;
+    uint8_t rt12;
+    uint8_t rt13;
+
+    uint8_t fc1;
+    uint8_t fc2;
+    uint8_t dur1;
+    uint8_t dur2;
+
+    uint8_t mac1_1; // Port
+	
+    int8_t signal;
+    uint32_t lostpackets;
+    int8_t signal_rc;
+    uint32_t lostpackets_rc;
+    uint8_t cpuload;
+    uint8_t temp;
+    uint32_t injected_block_cnt;
+    uint32_t skipped_fec_cnt;
+    uint32_t injection_fail_cnt;
+    long long injection_time_block;
+    uint16_t bitrate_kbit;
+    uint16_t bitrate_measured_kbit;
+    uint8_t cts;
+    uint8_t undervolt;
+}  __attribute__ ((__packed__));
+
+struct framedata_n framedatan;	
 
 struct framedata_s {
     uint8_t rt1;
@@ -87,8 +129,47 @@ struct framedata_s {
     uint8_t undervolt;
 }  __attribute__ ((__packed__));
 
-struct framedata_s framedata;
+struct framedata_s framedatas;
 
+struct framedata_l {
+    uint8_t rt1;
+    uint8_t rt2;
+    uint8_t rt3;
+    uint8_t rt4;
+    uint8_t rt5;
+    uint8_t rt6;
+    uint8_t rt7;
+    uint8_t rt8;
+
+    uint8_t rt9;
+    uint8_t rt10;
+    uint8_t rt11;
+    uint8_t rt12;
+
+    uint8_t fc1;
+    uint8_t fc2;
+    uint8_t dur1;
+    uint8_t dur2;
+
+    uint8_t mac1_1; // Port
+
+    int8_t signal;
+    uint32_t lostpackets;
+    int8_t signal_rc;
+    uint32_t lostpackets_rc;
+    uint8_t cpuload;
+    uint8_t temp;
+    uint32_t injected_block_cnt;
+    uint32_t skipped_fec_cnt;
+    uint32_t injection_fail_cnt;
+    long long injection_time_block;
+    uint16_t bitrate_kbit;
+    uint16_t bitrate_measured_kbit;
+    uint8_t cts;
+    uint8_t undervolt;
+}  __attribute__ ((__packed__));
+
+struct framedata_l framedatal;	
 
 void usage(void)
 {
@@ -151,58 +232,44 @@ static int open_sock (char *ifname) {
 }
 
 
-void sendRSSI(int sock, telemetry_data_t *td) {
-	if(td->rx_status != NULL) {
+void sendRSSI(int num_int, telemetry_data_t *td) {
+	int i;
+	for(i=0; i<num_int; ++i) {		
+	switch (type[i]) {
+	case 0: // type: Ralink
+	    if(td->rx_status != NULL) {
 		long double a[4], b[4];
 		FILE *fp;
 
 		int best_dbm = -127;
 		int best_dbm_rc = -127;
 		int cardcounter = 0;
-		int number_cards = td->rx_status->wifi_adapter_cnt;
 		int number_cards_rc = td->rx_status_rc->wifi_adapter_cnt;
-//		printf("num_cards:%d num_cards_rc:%d\n", number_cards,number_cards_rc);
-
-//		no_signal=true;
-//                for(cardcounter=0; cardcounter<number_cards; ++cardcounter) {
-//		    if (td->rx_status->adapter[cardcounter].signal_good == 1) { printf("card[%i] signal good\n",cardcounter); };
-//		    printf("dbm[%i]: %d  \n",cardcounter, td->rx_status->adapter[cardcounter].current_signal_dbm);
-//		    if (td->rx_status->adapter[cardcounter].signal_good == 1) {
-//                	if (best_dbm < td->rx_status->adapter[cardcounter].current_signal_dbm) best_dbm = td->rx_status->adapter[cardcounter].current_signal_dbm;
-//		    }
-//		    if (td->rx_status->adapter[cardcounter].signal_good == 1) no_signal=false;
-//                }
 
 		no_signal_rc=true;
-                for(cardcounter=0; cardcounter<number_cards_rc; ++cardcounter) {
-		    if (td->rx_status_rc->adapter[cardcounter].signal_good == 1) { printf("card[%i] rc signal good\n",cardcounter); };
-		    //printf("dbm_rc[%i]: %d\n",cardcounter, td->rx_status_rc->adapter[cardcounter].current_signal_dbm);
+        for(cardcounter=0; cardcounter<number_cards_rc; ++cardcounter) {
 		    if (td->rx_status_rc->adapter[cardcounter].signal_good == 1) {
-                	if (best_dbm_rc < td->rx_status_rc->adapter[cardcounter].current_signal_dbm) best_dbm_rc = td->rx_status_rc->adapter[cardcounter].current_signal_dbm;
-		    }
-		    if (td->rx_status_rc->adapter[cardcounter].signal_good == 1) no_signal_rc=false;
-                }
-
-		if (no_signal_rc == false) { printf("rc signal good   "); };
-		//printf("best_dbm_rc:%d\n",best_dbm_rc);
-
+                if (best_dbm_rc < td->rx_status_rc->adapter[cardcounter].current_signal_dbm) best_dbm_rc = td->rx_status_rc->adapter[cardcounter].current_signal_dbm;
+		            no_signal_rc=false;
+			}
+        }
 		if (no_signal == false) {
-		    framedata.signal = best_dbm;
+		    framedatal.signal = best_dbm;
 		} else {
-		    framedata.signal = -127;
+		    framedatal.signal = -127;
 		}
 		if (no_signal_rc == false) {
-		    framedata.signal_rc = best_dbm_rc;
+		    framedatal.signal_rc = best_dbm_rc;
 		} else {
-		    framedata.signal_rc = -127;
+		    framedatal.signal_rc = -127;
 		}
-		framedata.lostpackets = td->rx_status->lost_packet_cnt;
-		framedata.lostpackets_rc = td->rx_status_rc->lost_packet_cnt;
+		framedatal.lostpackets = td->rx_status->lost_packet_cnt;
+		framedatal.lostpackets_rc = td->rx_status_rc->lost_packet_cnt;
 
-		framedata.injected_block_cnt = td->tx_status->injected_block_cnt;
-		framedata.skipped_fec_cnt = td->tx_status->skipped_fec_cnt;
-		framedata.injection_fail_cnt = td->tx_status->injection_fail_cnt;
-		framedata.injection_time_block = td->tx_status->injection_time_block;
+		framedatal.injected_block_cnt = td->tx_status->injected_block_cnt;
+		framedatal.skipped_fec_cnt = td->tx_status->skipped_fec_cnt;
+		framedatal.injection_fail_cnt = td->tx_status->injection_fail_cnt;
+		framedatal.injection_time_block = td->tx_status->injection_time_block;
 
     		fp = fopen("/proc/stat","r");
     		fscanf(fp,"%*s %Lf %Lf %Lf %Lf",&a[0],&a[1],&a[2],&a[3]);
@@ -211,32 +278,144 @@ void sendRSSI(int sock, telemetry_data_t *td) {
     		fp = fopen("/proc/stat","r");
     		fscanf(fp,"%*s %Lf %Lf %Lf %Lf",&b[0],&b[1],&b[2],&b[3]);
     		fclose(fp);
-		framedata.cpuload = (((b[0]+b[1]+b[2]) - (a[0]+a[1]+a[2])) / ((b[0]+b[1]+b[2]+b[3]) - (a[0]+a[1]+a[2]+a[3]))) * 100;
+		framedatal.cpuload = (((b[0]+b[1]+b[2]) - (a[0]+a[1]+a[2])) / ((b[0]+b[1]+b[2]+b[3]) - (a[0]+a[1]+a[2]+a[3]))) * 100;
 
 		fp = fopen("/sys/class/thermal/thermal_zone0/temp","r");
 		int temp = 0;
 		fscanf(fp,"%d",&temp);
 		fclose(fp);
 		//fprintf(stderr,"temp: %d\n",temp/1000);
-		framedata.temp = temp / 1000;
+		framedatal.temp = temp / 1000;
 	}
-
-//	printf("signal: %d\n", framedata.signal);
-//	printf("skipped fec %d\n", td->tx_status->skipped_fec_cnt);
-//	printf("injection time: %lld\n", td->tx_status->injection_time_block);
-//	printf("injection time: %lld\n", td->tx_status->injection_time_block);
-
-//	fprintf(stdout,"\t\t%d blocks injected, injection time per block %lldus, %d fecs skipped, %d packet injections failed.          \r", td->tx_status->injected_block_cnt,td->tx_status->injection_time_block,td->tx_status->skipped_fec_cnt,td->tx_status->injection_fail_cnt);
-
-//	printf("signal_rc: %d\n", framedata.signal_rc);
-//	printf("lostpackets: %d\n", framedata.lostpackets);
-//	printf("lostpackets_rc: %d\n", framedata.lostpackets_rc);
-	// send three times with different delay in between to increase robustness against packetloss
-	if (write(socks[0], &framedata, 74) < 0 ) fprintf(stderr, "!");
+	//printf("signal_rc: %d\n", framedatal.signal_rc);
+	if (write(socks[i], &framedatal, 74) < 0 ) fprintf(stderr, "!");
 	usleep(1500);
-	if (write(socks[0], &framedata, 74) < 0 ) fprintf(stderr, "!");
+	if (write(socks[i], &framedatal, 74) < 0 ) fprintf(stderr, "!");
 	usleep(2000);
-	if (write(socks[0], &framedata, 74) < 0 ) fprintf(stderr, "!");
+	if (write(socks[i], &framedatal, 74) < 0 ) fprintf(stderr, "!");	
+	break;
+	case 1: // type: atheros
+		if(td->rx_status != NULL) {
+		long double a[4], b[4];
+		FILE *fp;
+
+		int best_dbm = -127;
+		int best_dbm_rc = -127;
+		int cardcounter = 0;
+		int number_cards_rc = td->rx_status_rc->wifi_adapter_cnt;
+
+		no_signal_rc=true;
+        for(cardcounter=0; cardcounter<number_cards_rc; ++cardcounter) {
+		    if (td->rx_status_rc->adapter[cardcounter].signal_good == 1) {
+                if (best_dbm_rc < td->rx_status_rc->adapter[cardcounter].current_signal_dbm) best_dbm_rc = td->rx_status_rc->adapter[cardcounter].current_signal_dbm;
+		            no_signal_rc=false;
+			}
+        }
+		if (no_signal == false) {
+		    framedatas.signal = best_dbm;
+		} else {
+		    framedatas.signal = -127;
+		}
+		if (no_signal_rc == false) {
+		    framedatas.signal_rc = best_dbm_rc;
+		} else {
+		    framedatas.signal_rc = -127;
+		}
+		framedatas.lostpackets = td->rx_status->lost_packet_cnt;
+		framedatas.lostpackets_rc = td->rx_status_rc->lost_packet_cnt;
+
+		framedatas.injected_block_cnt = td->tx_status->injected_block_cnt;
+		framedatas.skipped_fec_cnt = td->tx_status->skipped_fec_cnt;
+		framedatas.injection_fail_cnt = td->tx_status->injection_fail_cnt;
+		framedatas.injection_time_block = td->tx_status->injection_time_block;
+
+    		fp = fopen("/proc/stat","r");
+    		fscanf(fp,"%*s %Lf %Lf %Lf %Lf",&a[0],&a[1],&a[2],&a[3]);
+    		fclose(fp);
+    		usleep(333333); // send about 3 times per second
+    		fp = fopen("/proc/stat","r");
+    		fscanf(fp,"%*s %Lf %Lf %Lf %Lf",&b[0],&b[1],&b[2],&b[3]);
+    		fclose(fp);
+		framedatas.cpuload = (((b[0]+b[1]+b[2]) - (a[0]+a[1]+a[2])) / ((b[0]+b[1]+b[2]+b[3]) - (a[0]+a[1]+a[2]+a[3]))) * 100;
+
+		fp = fopen("/sys/class/thermal/thermal_zone0/temp","r");
+		int temp = 0;
+		fscanf(fp,"%d",&temp);
+		fclose(fp);
+		//fprintf(stderr,"temp: %d\n",temp/1000);
+		framedatas.temp = temp / 1000;
+	}
+	//printf("signal_rc: %d\n", framedatas.signal_rc);
+	if (write(socks[i], &framedatas, 74) < 0 ) fprintf(stderr, "!");
+	usleep(1500);
+	if (write(socks[i], &framedatas, 74) < 0 ) fprintf(stderr, "!");
+	usleep(2000);
+	if (write(socks[i], &framedatas, 74) < 0 ) fprintf(stderr, "!");
+	break;
+	case 2: // type: Realtek
+	    if(td->rx_status != NULL) {
+		long double a[4], b[4];
+		FILE *fp;
+
+		int best_dbm = -127;
+		int best_dbm_rc = -127;
+		int cardcounter = 0;
+		int number_cards_rc = td->rx_status_rc->wifi_adapter_cnt;
+
+		no_signal_rc=true;
+        for(cardcounter=0; cardcounter<number_cards_rc; ++cardcounter) {
+		    if (td->rx_status_rc->adapter[cardcounter].signal_good == 1) {
+                if (best_dbm_rc < td->rx_status_rc->adapter[cardcounter].current_signal_dbm) best_dbm_rc = td->rx_status_rc->adapter[cardcounter].current_signal_dbm;
+		            no_signal_rc=false;
+			}
+        }
+		if (no_signal == false) {
+		    framedatan.signal = best_dbm;
+		} else {
+		    framedatan.signal = -127;
+		}
+		if (no_signal_rc == false) {
+		    framedatan.signal_rc = best_dbm_rc;
+		} else {
+		    framedatan.signal_rc = -127;
+		}
+		framedatan.lostpackets = td->rx_status->lost_packet_cnt;
+		framedatan.lostpackets_rc = td->rx_status_rc->lost_packet_cnt;
+
+		framedatan.injected_block_cnt = td->tx_status->injected_block_cnt;
+		framedatan.skipped_fec_cnt = td->tx_status->skipped_fec_cnt;
+		framedatan.injection_fail_cnt = td->tx_status->injection_fail_cnt;
+		framedatan.injection_time_block = td->tx_status->injection_time_block;
+
+    		fp = fopen("/proc/stat","r");
+    		fscanf(fp,"%*s %Lf %Lf %Lf %Lf",&a[0],&a[1],&a[2],&a[3]);
+    		fclose(fp);
+    		usleep(333333); // send about 3 times per second
+    		fp = fopen("/proc/stat","r");
+    		fscanf(fp,"%*s %Lf %Lf %Lf %Lf",&b[0],&b[1],&b[2],&b[3]);
+    		fclose(fp);
+		framedatan.cpuload = (((b[0]+b[1]+b[2]) - (a[0]+a[1]+a[2])) / ((b[0]+b[1]+b[2]+b[3]) - (a[0]+a[1]+a[2]+a[3]))) * 100;
+
+		fp = fopen("/sys/class/thermal/thermal_zone0/temp","r");
+		int temp = 0;
+		fscanf(fp,"%d",&temp);
+		fclose(fp);
+		//fprintf(stderr,"temp: %d\n",temp/1000);
+		framedatan.temp = temp / 1000;
+	}
+	//printf("signal_rc: %d\n", framedatan.signal_rc);
+	if (write(socks[i], &framedatan, 74) < 0 ) fprintf(stderr, "!");
+	usleep(1500);
+	if (write(socks[i], &framedatan, 74) < 0 ) fprintf(stderr, "!");
+	usleep(2000);
+	if (write(socks[i], &framedatan, 74) < 0 ) fprintf(stderr, "!");	
+	break;
+	default:
+    fprintf(stderr, "ERROR: Wrong or no frame type specified (see -t parameter)\n");
+	exit(1);
+	break;
+  }
+  }
 }
 
 
@@ -288,9 +467,70 @@ int main (int argc, char *argv[]) {
 	setpriority(PRIO_PROCESS, 0, 10);
 
 	int done = 1;
+	char line[100], path[100];
+    FILE* procfile;
+	
+    while (1) {
+	int nOptionIndex;
+	static const struct option optiona[] = {
+	    { "help", no_argument, &flagHelp, 1 },
+	    { 0, 0, 0, 0 }
+	};
+	int c = getopt_long(argc, argv, "h:",
+	    optiona, &nOptionIndex);
 
-//	fprintf(stderr,"RSSI TX started\n");
-	socks[0] = open_sock(argv[1]);
+	if (c == -1)
+	    break;
+	switch (c) {
+	case 0: // long option
+	    break;
+	case 'h': // help
+	    usage();
+	    break;
+	default:
+	    fprintf(stderr, "unknown switch %c\n", c);
+	    usage();
+	}
+    }
+	
+    if (optind >= argc) usage();
+
+    int x = optind;
+    int num_interfaces = 0;
+
+    while(x < argc && num_interfaces < 5) {
+    	snprintf(path, 45, "/sys/class/net/%s/device/uevent", argv[x]);
+        procfile = fopen(path, "r");
+        if(!procfile) {fprintf(stderr,"ERROR: opening %s failed!\n", path); return 0;}
+        fgets(line, 100, procfile); // read the first line
+        fgets(line, 100, procfile); // read the 2nd line
+	if (strncmp(line, "DRIVER=ath9k_htc", 16) == 0 || 
+        (
+         strncmp(line, "DRIVER=8812au",    13) == 0 || 
+         strncmp(line, "DRIVER=8814au",    13) == 0 || 
+         strncmp(line, "DRIVER=rtl8812au", 16) == 0 || 
+         strncmp(line, "DRIVER=rtl8814au", 16) == 0 || 
+         strncmp(line, "DRIVER=rtl88xxau", 16) == 0
+        )) {   
+		if (strncmp(line, "DRIVER=ath9k_htc", 16) == 0) {
+			  fprintf(stderr, "rssitx: Atheros card detected\n");
+	          type[num_interfaces] = 1;
+		} else {
+			  fprintf(stderr, "rssitx: Realtek card detected\n");
+			  type[num_interfaces] = 2;
+		}
+    } else { // ralink or mediatek
+              fprintf(stderr, "rssitx: Ralink card detected\n");
+	          type[num_interfaces] = 0;
+    }
+	socks[num_interfaces] = open_sock(argv[x]);
+        ++num_interfaces;
+	++x;
+        fclose(procfile);
+        usleep(10000); // wait a bit between configuring interfaces to reduce Atheros and Pi USB flakiness
+    }
+	//	fprintf(stderr,"RSSI TX started\n");
+	//socks[0] = open_sock(argv[3]);
 
 	FILE * pFile;
 	int bitrate_kbit;
@@ -335,70 +575,153 @@ int main (int argc, char *argv[]) {
 
 	telemetry_data_t td;
 	telemetry_init(&td);
+	
+	    framedatan.rt1 = 0; // <-- radiotap version      (0x00)
+	    framedatan.rt2 = 0; // <-- radiotap version      (0x00)
 
-	framedata.rt1 = 0; // <-- radiotap version
-	framedata.rt2 = 0; // <-- radiotap version
+	    framedatan.rt3 = 13; // <- radiotap header length(0x0d)
+	    framedatan.rt4 = 0; // <- radiotap header length (0x00)
 
-	framedata.rt3 = 12; // <- radiotap header length
-	framedata.rt4 = 0; // <- radiotap header length
+	    framedatan.rt5 = 0; // <-- radiotap present flags(0x00)
+	    framedatan.rt6 = 128; // <-- RADIOTAP_TX_FLAGS + (0x80)
+	    framedatan.rt7 = 8; // <--  RADIOTAP_MCS         (0x08)
+	    framedatan.rt8 = 0; //                           (0x00)
 
-	framedata.rt5 = 4; // <-- radiotap present flags
-	framedata.rt6 = 128; // <-- radiotap present flags
-	framedata.rt7 = 0; // <-- radiotap present flags
-	framedata.rt8 = 0; // <-- radiotap present flags
+	    framedatan.rt9 = 8; // <-- RADIOTAP_F_TX_NOACK   (0x08)
+	    framedatan.rt10 = 0; //                          (0x00)
+	    framedatan.rt11 = 55; // <-- bitmap              (0x37)
+	    framedatan.rt12 = 48; // <-- flags               (0x30)
+	    framedatan.rt13 = 0; // <-- mcs_index            (0x00)
 
-	framedata.rt9 = 24; // <-- radiotap rate
-	framedata.rt10 = 0; // <-- radiotap stuff
-	framedata.rt11 = 0; // <-- radiotap stuff
-	framedata.rt12 = 0; // <-- radiotap stuff
+	    framedatan.fc1 = 180; // <-- frame control field (0x08 = 8 = data frame) (0xb4 = 180 = rts frame)
+	    framedatan.fc2 = 1; // <-- frame control field 0x02，0x01，0xbf
+	    framedatan.dur1 = 0; // <-- duration
+	    framedatan.dur2 = 0; // <-- duration
 
-	framedata.fc1 = 8; // <-- frame control field 0x08 = 8 data frame (180 = rts frame)
-	framedata.fc2 = 2; // <-- frame control field 0x02 = 2
-	framedata.dur1 = 0; // <-- duration
-	framedata.dur2 = 0; // <-- duration
+	    framedatan.mac1_1 = 127 ; // (0x7F) port 63
+		
+		framedatan.signal = 0;
+	    framedatan.lostpackets = 0;
+	    framedatan.signal_rc = 0;
+	    framedatan.lostpackets_rc = 0;
+	    framedatan.cpuload = 0;
+	    framedatan.temp = 0;
+	    framedatan.injected_block_cnt = 0;
+	    framedatan.skipped_fec_cnt = 0;
+	    framedatan.injection_fail_cnt = 0;
+	    framedatan.injection_time_block = 0;
 
-	framedata.mac1_1 = 255 ; // port 127
-	framedata.mac1_2 = 0;
-	framedata.mac1_3 = 0;
-	framedata.mac1_4 = 0;
-	framedata.mac1_5 = 0;
-	framedata.mac1_6 = 0;
+	    framedatan.bitrate_kbit = bitrate_kbit;
+	    framedatan.bitrate_measured_kbit = bitrate_measured_kbit;
+	    framedatan.cts = cts;
+	    framedatan.undervolt = undervolt;
 
-	framedata.mac2_1 = 0;
-	framedata.mac2_2 = 0;
-	framedata.mac2_3 = 0;
-	framedata.mac2_4 = 0;
-	framedata.mac2_5 = 0;
-	framedata.mac2_6 = 0;
+		
+		
+	    framedatas.rt1 = 0; // <-- radiotap version
+	    framedatas.rt2 = 0; // <-- radiotap version
 
-	framedata.mac3_1 = 0;
-	framedata.mac3_2 = 0;
-	framedata.mac3_3 = 0;
-	framedata.mac3_4 = 0;
-	framedata.mac3_5 = 0;
-	framedata.mac3_6 = 0;
+	    framedatas.rt3 = 12; // <- radiotap header length
+	    framedatas.rt4 = 0; // <- radiotap header length
 
-	framedata.ieeeseq1 = 0;
-	framedata.ieeeseq2 = 0;
+	    framedatas.rt5 = 4; // <-- radiotap present flags
+	    framedatas.rt6 = 128; // <-- radiotap present flags
+	    framedatas.rt7 = 0; // <-- radiotap present flags
+	    framedatas.rt8 = 0; // <-- radiotap present flags
 
-	framedata.signal = 0;
-	framedata.lostpackets = 0;
-	framedata.signal_rc = 0;
-	framedata.lostpackets_rc = 0;
-	framedata.cpuload = 0;
-	framedata.temp = 0;
-	framedata.injected_block_cnt = 0;
-	framedata.skipped_fec_cnt = 0;
-	framedata.injection_fail_cnt = 0;
-	framedata.injection_time_block = 0;
+	    framedatas.rt9 = 24; // <-- radiotap rate
+	    framedatas.rt10 = 0; // <-- radiotap stuff
+	    framedatas.rt11 = 0; // <-- radiotap stuff
+	    framedatas.rt12 = 0; // <-- radiotap stuff
 
-	framedata.bitrate_kbit = bitrate_kbit;
-	framedata.bitrate_measured_kbit = bitrate_measured_kbit;
-	framedata.cts = cts;
-	framedata.undervolt = undervolt;
+	    framedatas.fc1 = 8; // <-- frame control field 0x08 = 8 data frame (180 = rts frame)
+	    framedatas.fc2 = 2; // <-- frame control field 0x02 = 2
+	    framedatas.dur1 = 0; // <-- duration
+	    framedatas.dur2 = 0; // <-- duration
 
+	    framedatas.mac1_1 = 127 ; // (0x7F) port 63
+	    framedatas.mac1_2 = 0;
+	    framedatas.mac1_3 = 0;
+	    framedatas.mac1_4 = 0;
+	    framedatas.mac1_5 = 0;
+	    framedatas.mac1_6 = 0;
+
+	    framedatas.mac2_1 = 0;
+	    framedatas.mac2_2 = 0;
+	    framedatas.mac2_3 = 0;
+	    framedatas.mac2_4 = 0;
+	    framedatas.mac2_5 = 0;
+	    framedatas.mac2_6 = 0;
+
+	    framedatas.mac3_1 = 0;
+	    framedatas.mac3_2 = 0;
+	    framedatas.mac3_3 = 0;
+	    framedatas.mac3_4 = 0;
+	    framedatas.mac3_5 = 0;
+	    framedatas.mac3_6 = 0;
+
+	    framedatas.ieeeseq1 = 0;
+	    framedatas.ieeeseq2 = 0;
+		
+		framedatas.signal = 0;
+	    framedatas.lostpackets = 0;
+	    framedatas.signal_rc = 0;
+	    framedatas.lostpackets_rc = 0;
+	    framedatas.cpuload = 0;
+	    framedatas.temp = 0;
+	    framedatas.injected_block_cnt = 0;
+	    framedatas.skipped_fec_cnt = 0;
+	    framedatas.injection_fail_cnt = 0;
+	    framedatas.injection_time_block = 0;
+
+	    framedatas.bitrate_kbit = bitrate_kbit;
+	    framedatas.bitrate_measured_kbit = bitrate_measured_kbit;
+	    framedatas.cts = cts;
+	    framedatas.undervolt = undervolt;
+		
+  
+  
+	    framedatal.rt1 = 0; // <-- radiotap version
+	    framedatal.rt2 = 0; // <-- radiotap version
+
+	    framedatal.rt3 = 12; // <- radiotap header length
+	    framedatal.rt4 = 0; // <- radiotap header length
+
+	    framedatal.rt5 = 4; // <-- radiotap present flags
+	    framedatal.rt6 = 128; // <-- radiotap present flags
+	    framedatal.rt7 = 0; // <-- radiotap present flags
+	    framedatal.rt8 = 0; // <-- radiotap present flags
+
+	    framedatal.rt9 = 24; // <-- radiotap rate
+	    framedatal.rt10 = 0; // <-- radiotap stuff
+	    framedatal.rt11 = 0; // <-- radiotap stuff
+	    framedatal.rt12 = 0; // <-- radiotap stuff
+
+	    framedatal.fc1 = 8; // <-- frame control field 0x08 = 8 data frame (180 = rts frame)
+	    framedatal.fc2 = 1; // <-- frame control field 0x01 = 1
+	    framedatal.dur1 = 0; // <-- duration
+	    framedatal.dur2 = 0; // <-- duration
+
+	    framedatal.mac1_1 = 127 ; //1st byte of mac (0x7F) for portnumber 63((127-1)/2 for rssi)
+		
+		framedatal.signal = 0;
+	    framedatal.lostpackets = 0;
+	    framedatal.signal_rc = 0;
+	    framedatal.lostpackets_rc = 0;
+	    framedatal.cpuload = 0;
+	    framedatal.temp = 0;
+	    framedatal.injected_block_cnt = 0;
+	    framedatal.skipped_fec_cnt = 0;
+	    framedatal.injection_fail_cnt = 0;
+	    framedatal.injection_time_block = 0;
+
+	    framedatal.bitrate_kbit = bitrate_kbit;
+	    framedatal.bitrate_measured_kbit = bitrate_measured_kbit;
+	    framedatal.cts = cts;
+	    framedatal.undervolt = undervolt;
+		
 	while (done) {
-		sendRSSI(sock,&td);
+		sendRSSI(num_interfaces,&td);
 	}
 	return 0;
 }


### PR DESCRIPTION
Automatic check wifi card type, for rtl8812au use 802.11n MCS 0 frame RTS package, and enable STBC,LDPC.Modify 1st byte of MAC (0x7F) uesd port number 63, original 0xFF for portnumber 127. Avoid conflict with svpcom n80211Header 0xFF.