### PR TITLE
Send ConfigEnd=ConfigEnd to apps when done reading settings

### DIFF
--- a/RemoteSettings/RemoteSettings.py
+++ b/RemoteSettings/RemoteSettings.py
@@ -25,6 +25,7 @@ IPAndroidClient = ""
 IsPhoneThredRunning = 0
 
 ConfigResp = bytearray(b'ConfigResp')
+ConfigEnd = bytearray(b'ConfigRespConfigEnd=ConfigEnd')
 RequestAllSettings = bytearray(b'RequestAllSettings')
 RequestChangeSettings = bytearray(b'RequestChangeSettings')
 RequestChangeOSD = bytearray(b'RequestChangeOSD')
@@ -210,6 +211,8 @@ read_osd_settings(complete_response)
 read_joystick_settings(complete_response)
 
 def SendAllSettingToPhone():
+    global IPAndroidClient
+
     for te in complete_response['settings']:
         
         SendBuff = bytearray()
@@ -226,11 +229,11 @@ def SendAllSettingToPhone():
         ValueDataPayload = data.encode('utf-8')
         SendBuff.extend(ValueDataPayload)
 
-        global IPAndroidClient
         SendData(IPAndroidClient,SendBuff)
         print("v :", SendBuff)
         SendBuff.clear()
         sleep(0.02)
+    SendData(IPAndroidClient, ConfigEnd)
 
 def ConfirmSave(VarName):
     SendBuffSave = bytearray()


### PR DESCRIPTION
When apps read the ground station settings over UDP, the ground station will now send back an end delimiter (ConfigEnd=ConfigEnd) after it has sent all of the settings key/value pairs, which allows apps to know when they've actually received all of them.

Otherwise they have to use timers or assume that the ground station might send any value at any time, which makes it difficult to coordinate loading/saving indicators and other UI actions.

This change has been tested with released builds of the Android settings app and doesn't cause it to break or change behavior (it hardcodes all the settings values and ignores this entirely).