### PR TITLE
Remove duplicate hotspot shutdown message

### DIFF
--- a/wifibroadcast-scripts/hotspot_functions.sh
+++ b/wifibroadcast-scripts/hotspot_functions.sh
@@ -144,10 +144,8 @@ function hotspot_check_function {
 	  	fi 
 		
 		if [ "$HOTSPOT_TIMEOUT" != "0" ]; then
-			nice /home/pi/wifibroadcast-status/wbc_status "Hotspot Shutting Down in $HOTSPOT_TIMEOUT seconds" 7 55 0
-    			sleep $HOTSPOT_TIMEOUT
-			nice /home/pi/wifibroadcast-status/wbc_status "Hotspot Shutting Down in 10s" 7 55 0
-    			sleep 10
+			nice /home/pi/wifibroadcast-status/wbc_status "Hotspot Shutting Down in ${HOTSPOT_TIMEOUT} seconds" 7 55 0
+    		sleep $HOTSPOT_TIMEOUT
    			killall hostapd
 			ps -ef | nice grep "wifihotspot" | nice grep -v grep | awk '{print $2}' | xargs kill -9
 			nice /home/pi/wifibroadcast-status/wbc_status "Hotspot Shut Down" 7 55 0


### PR DESCRIPTION
This is just removing the 2nd "Hotspot Shutting Down in x" message, we had 2 of them.

The first uses the configured time from settings, then pauses for that length of time, then another message is shown saying it will shut down in 10 seconds.