### PR TITLE
Send telemetry to QOpenHD on 127.0.0.1:5155

### DIFF
--- a/wifibroadcast-scripts/hotspot_functions.sh
+++ b/wifibroadcast-scripts/hotspot_functions.sh
@@ -61,7 +61,8 @@ function hotspot_check_function {
 	##OpenHD RemoteSettings android app
 	/home/pi/wifibroadcast-scripts/UDPsplitterhelper.sh 9125 5116 5115 &
 
-
+        # used for QOpenHD when running on the ground pi itself
+        nice /home/pi/wifibroadcast-base/rssi_qgc_forward 127.0.0.1 5155 &
 
 
         #if [ "$TELEMETRY_UPLINK" == "msp" ]; then


### PR DESCRIPTION
Only used when QOpenHD is running on the ground station itself, when running remotely it uses the same 5154 port as always.

The change is to avoid having to use the shared memory system directly from QOpenHD and to ensure the app works the same everywhere.

This change should not impact anything else, it is read-only with respect to the shared memory telemetry system on the ground station, and port 5155 is previously unused. The packet rate is slow so it shouldn't cause any increased load, and the packets will simply get dropped if QOpenHD isn't running.